### PR TITLE
use coverage.py with pytest in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,5 +4,10 @@ envlist=py27,pypy
 basepython =
     py27: python2.7
     pypy: {toxinidir}/download/pypy-2.6.0-linux64/bin/pypy
-deps=pytest
-commands=py.test
+deps = 
+    pytest
+    coverage
+
+commands=
+    coverage run --source zerodb --branch -m pytest test
+    coverage report -m 


### PR DESCRIPTION
[Coverage.py](https://coverage.readthedocs.org/en/coverage-4.0.3/) could be used to test the coverage rate of tests, and show the lines which are not covered. It also integrates well with pytest and tox. For example, current run shows the coverage is 72%

```
...
zerodb/trees/OOBTree.py                  17      0      0      0   100%
zerodb/trees/__init__.py                 13      0      0      0   100%
zerodb/util/__init__.py                   0      0      0      0   100%
zerodb/util/debug.py                      9      0      2      1    91%   13->-13
zerodb/util/iter.py                     102      7     42      5    90%   33-36, 56, 132-135, 21->-19, 27->33, 54->56, 128->138, 129->132
zerodb/util/thread_watcher.py            32      7      2      1    76%   37, 42-47, 25->-24
---------------------------------------------------------------------------------
TOTAL                                  1771    415    539     95    72%
```