### PR TITLE
Replace deprecated zope.interface.implements

### DIFF
--- a/zerodb/collective/indexing/indexer.py
+++ b/zerodb/collective/indexing/indexer.py
@@ -1,4 +1,4 @@
-from zope.interface import implements
+from zope.interface import implementer
 from zerodb.collective.indexing.interfaces import IIndexQueueProcessor
 
 
@@ -7,8 +7,8 @@ class IPortalCatalogQueueProcessor(IIndexQueueProcessor):
         the `CatalogMultiplex` and `CMFCatalogAware` mixin classes """
 
 
+@implementer(IPortalCatalogQueueProcessor)
 class PortalCatalogProcessor(object):
-    implements(IPortalCatalogQueueProcessor)
 
     def index(self, obj, attributes=None):
         #index(obj, attributes)

--- a/zerodb/collective/indexing/queue.py
+++ b/zerodb/collective/indexing/queue.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 from threading import local
-from zope.interface import implements
+from zope.interface import implementer
 from zope.component import getSiteManager
 
 from zerodb.collective.indexing.interfaces import IIndexQueue
@@ -41,9 +41,8 @@ def processQueue():
     return processed
 
 
+@implementer(IIndexQueue)
 class IndexQueue(local):
-
-    implements(IIndexQueue)
 
     def __init__(self):
         self.queue = []

--- a/zerodb/collective/indexing/transactions.py
+++ b/zerodb/collective/indexing/transactions.py
@@ -2,7 +2,7 @@ from logging import getLogger
 from threading import local
 from transaction.interfaces import ISavepointDataManager
 from transaction import get as getTransaction
-from zope.interface import implements
+from zope.interface import implementer
 
 logger = getLogger('collective.indexing.transactions')
 
@@ -18,9 +18,9 @@ class QueueSavepoint(object):
         self.queue.setState(self.state)
 
 
+@implementer(ISavepointDataManager)
 class QueueTM(local):
     """ transaction manager hook for the indexing queue """
-    implements(ISavepointDataManager)
 
     def __init__(self, queue):
         local.__init__(self)


### PR DESCRIPTION
zope.interface.implementer supports both python2 and python3 (see https://github.com/zopefoundation/zope.interface/blob/master/CHANGES.rst#400-2012-05-16)